### PR TITLE
Set websocket=True for Rule, fixes #81

### DIFF
--- a/flask_sockets.py
+++ b/flask_sockets.py
@@ -75,7 +75,7 @@ class Sockets(object):
         return decorator
 
     def add_url_rule(self, rule, _, f, **options):
-        self.url_map.add(Rule(rule, endpoint=f))
+        self.url_map.add(Rule(rule, endpoint=f, websocket=True))
 
     def register_blueprint(self, blueprint, **options):
         """


### PR DESCRIPTION
This fixes the `WebsocketMismatch` which appears with Werkzeug 2.0.0.

The cause is a websocket request hits a rule which Werkzeug doesn't think is a websocket endpoint.